### PR TITLE
Update ngl-message-bot.js

### DIFF
--- a/ngl-message-bot.js
+++ b/ngl-message-bot.js
@@ -4,12 +4,11 @@ let counter = 0;
 
 const sendMessage = async (username, message) => {
     while (true) {
-        try {
             const date = new Date();
             const minutes = date.getMinutes();
             const hours = date.getHours();
             const formattedDate = `${hours}:${minutes}`;
-
+        try {
             const deviceId = crypto.randomBytes(21).toString("hex");
             const url = "https://ngl.link/api/submit";
             const headers = {


### PR DESCRIPTION
the file wpuld quit in case of an error, since `formattedDate` was declared inside the try block with const, so catch block is unable to access it. 

the output would be:

            **console.error(`[${formattedDate}] [Err] ${error}`);
                              ^

ReferenceError: formattedDate is not defined**

i moved the declaration of the variable, outside the try block. it should be accesible from the catch now.
another option could be using the 'var' keyword, but this would overwrite the variable.

good luck with node.js and programming.  i suggest you to pay more attention to codeblocks.
